### PR TITLE
added shardSessionLock to prevent concurrent write panic - added test

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -268,8 +268,9 @@ func (s *Session) recursivePutRow(name string, row interface{}, pqTablePath stri
 	curTable := tbuf.Table
 
 	// Here we force the primary key to be handled first for table so that columnID is established in tbuf
-	if hasValues, err := s.processPrimaryKey(tbuf, row, pqTablePath, providedColID, isChild,
-		ignoreSourcePath, useNerdCapitalization); err != nil {
+	hasValues, err := s.processPrimaryKey(tbuf, row, pqTablePath, providedColID, isChild,
+		ignoreSourcePath, useNerdCapitalization)
+	if err != nil {
 		return err
 	} else if !hasValues {
 		return nil // nothing to do, no values in child relation

--- a/quanta-kinesis-consumer-lib/README.md
+++ b/quanta-kinesis-consumer-lib/README.md
@@ -1,0 +1,36 @@
+
+
+### Set up localstack for local testing of AWS api's 
+
+Using a terminal and a package manager install once:
+```
+	brew install localstack
+	localstack --version
+```
+get
+```
+    3.2.0
+```
+In a new terminal window:
+```
+    localstack start
+```
+Leave that running and, in a different terminal window. 
+```
+    pip install awscli-local
+```
+Try:
+```
+	awslocal s3api create-bucket --bucket sample-bucket
+```
+and get
+```
+{
+    "Location": "/sample-bucket"
+}
+```
+This is how we can do AWS commands:
+```
+	awslocal s3 ls
+		2024-03-24 04:21:13 sample-bucket
+```

--- a/quanta-kinesis-consumer-lib/q-kinesis-lib.go
+++ b/quanta-kinesis-consumer-lib/q-kinesis-lib.go
@@ -1,0 +1,670 @@
+package q_kinesis_lib
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	u "github.com/araddon/gou"
+
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/disney/quanta/core"
+	"github.com/disney/quanta/qlbridge/datasource"
+	"github.com/disney/quanta/qlbridge/expr"
+	"github.com/disney/quanta/qlbridge/value"
+	"github.com/disney/quanta/qlbridge/vm"
+	"github.com/disney/quanta/shared"
+	"github.com/hamba/avro/v2"
+	consumer "github.com/harlow/kinesis-consumer"
+	store "github.com/harlow/kinesis-consumer/store/ddb"
+	"github.com/hashicorp/consul/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stvp/rendezvous"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	Success          = 0 // Exit code for success
+	AppName          = "Kinesis-Consumer"
+	ShardChannelSize = 10000
+)
+
+// Main struct defines command line arguments variables and various global meta-data associated with record loads.
+type Main struct {
+	Stream      string
+	Region      string
+	Schema      string
+	TotalBytes  *Counter
+	totalBytesL *Counter
+	TotalRecs   *Counter
+	totalRecsL  *Counter
+	errorCount  *Counter
+	// poolPercent         *Counter
+	Port       int
+	ConsulAddr string
+	ShardCount int
+	// lock                *api.Lock
+	Consumer            *consumer.Consumer
+	InitialPos          string
+	IsAvro              bool
+	CheckpointDB        bool
+	CheckpointTable     string
+	AssumeRoleArn       string
+	AssumeRoleArnRegion string
+	Deaggregate         bool
+	Collate             bool
+	ShardKey            string
+	HashTable           *rendezvous.Table
+	shardChannels       map[string]chan DataRecord
+	shardSessionCache   map[string]*core.Session
+	shardSessionLock    sync.Mutex
+	eg                  errgroup.Group
+	CancelFunc          context.CancelFunc
+	CommitIntervalMs    int
+	processedRecs       *Counter
+	processedRecL       *Counter
+	ScanInterval        int
+	metrics             *cloudwatch.CloudWatch
+	tableCache          *core.TableCacheStruct
+}
+
+// NewMain allocates a new pointer to Main struct with empty record counter
+func NewMain() *Main {
+	m := &Main{
+		TotalRecs:     &Counter{},
+		totalRecsL:    &Counter{},
+		TotalBytes:    &Counter{},
+		totalBytesL:   &Counter{},
+		processedRecs: &Counter{},
+		processedRecL: &Counter{},
+		errorCount:    &Counter{},
+	}
+	m.tableCache = core.NewTableCacheStruct()
+	return m
+}
+
+type DataRecord struct {
+	TableName string
+	Data      map[string]interface{}
+}
+
+// Init function initilizations loader.
+// Establishes session with bitmap server and Kinesis
+func (m *Main) Init(customEndpoint string) (int, error) {
+
+	consulConfig := &api.Config{Address: m.ConsulAddr}
+	consulClient, err := api.NewClient(consulConfig)
+	if err != nil {
+		return 0, err
+	}
+
+	// Register for Schema changes
+	err = shared.RegisterSchemaChangeListener(consulConfig, m.schemaChangeListener)
+	if err != nil {
+		return 0, err
+	}
+
+	clientConn := shared.NewDefaultConnection("kinesis-consumer")
+	clientConn.ServicePort = m.Port
+	clientConn.Quorum = 3
+	if err := clientConn.Connect(consulClient); err != nil {
+		u.Error(err)
+		os.Exit(1)
+	}
+
+	// Register member leave/join
+	//clientConn.RegisterService(m)
+	sess, errx := session.NewSession(&aws.Config{
+		Region:   aws.String(m.Region),
+		Endpoint: aws.String(customEndpoint),
+	})
+	if errx != nil {
+		return 0, errx
+	}
+
+	var kc *kinesis.Kinesis
+	if m.AssumeRoleArn != "" {
+		creds := stscreds.NewCredentials(sess, m.AssumeRoleArn)
+		config := aws.NewConfig().
+			WithCredentials(creds).
+			WithRegion(m.AssumeRoleArnRegion).
+			WithMaxRetries(10)
+		kc = kinesis.New(sess, config)
+	} else {
+		kc = kinesis.New(sess)
+	}
+
+	streamName := aws.String(m.Stream)
+	shout, err := kc.ListShards(&kinesis.ListShardsInput{StreamName: streamName})
+	if err != nil {
+		return 0, err
+	}
+	shardCount := len(shout.Shards)
+	dynamoDbClient := dynamodb.New(sess)
+
+	db, err := store.New(AppName, m.CheckpointTable, store.WithDynamoClient(dynamoDbClient), store.WithRetryer(&QuantaRetryer{}))
+	if err != nil {
+		u.Errorf("checkpoint storage initialization error: %v", err)
+		os.Exit(1)
+	}
+
+	if m.CheckpointDB {
+		m.Consumer, err = consumer.New(
+			m.Stream,
+			consumer.WithClient(kc),
+			consumer.WithShardIteratorType(m.InitialPos),
+			consumer.WithStore(db),
+			consumer.WithAggregation(m.Deaggregate),
+			consumer.WithScanInterval(time.Duration(m.ScanInterval)*time.Millisecond),
+			//consumer.WithCounter(counter),
+		)
+	} else {
+		m.Consumer, err = consumer.New(
+			m.Stream,
+			consumer.WithClient(kc),
+			consumer.WithShardIteratorType(m.InitialPos),
+			consumer.WithAggregation(m.Deaggregate),
+			consumer.WithScanInterval(time.Duration(m.ScanInterval)*time.Millisecond),
+			//consumer.WithCounter(counter),
+		)
+	}
+	if err != nil {
+		return 0, err
+	}
+	m.metrics = cloudwatch.New(sess)
+
+	// Initialize shard channels
+	u.Warnf("Shard count = %d", shardCount)
+	m.shardChannels = make(map[string]chan DataRecord)
+	m.shardSessionCache = make(map[string]*core.Session)
+	shardIds := make([]string, shardCount)
+	// ClearTableCache
+	for k := range m.tableCache.TableCache {
+		delete(m.tableCache.TableCache, k)
+	}
+
+	// open all tables to populate the TableCache
+	tables, err := shared.GetTables(consulClient)
+	if err != nil {
+		return 0, err
+	}
+	for _, tableName := range tables {
+		u.Infof("Opening session for table %s", tableName)
+		// what are these orphans sessions for?
+		conn, _ := core.OpenSession(m.tableCache, "", tableName, false, clientConn)
+		if conn != nil {
+			conn.CloseSession()
+		}
+	}
+
+	// we have to do this in two passes
+	// we don't want to lookup shardChannels while the init is still writing that map.
+	// 1.  Create the shard channels
+	// 2.  Start the go routines
+
+	for i := 0; i < shardCount; i++ {
+		k := fmt.Sprintf("shard%v", i)
+		shardIds[i] = k
+		m.shardChannels[k] = make(chan DataRecord, ShardChannelSize)
+	}
+
+	for i := 0; i < shardCount; i++ {
+
+		k := fmt.Sprintf("shard%v", i)
+		// shardIds[i] = k
+		// m.shardChannels[k] = make(chan DataRecord, ShardChannelSize)
+		shardId := k
+		theChan := m.shardChannels[k]
+		m.eg.Go(func() error {
+			nextCommit := time.Now().Add(time.Millisecond * time.Duration(m.CommitIntervalMs))
+			for rec := range theChan {
+				shardTableKey := fmt.Sprintf("%v+%v", shardId, rec.TableName)
+				m.shardSessionLock.Lock()
+				conn, ok := m.shardSessionCache[shardTableKey] // cache lookup
+				m.shardSessionLock.Unlock()
+				if !ok {
+					conn, err = core.OpenSession(m.tableCache, "", rec.TableName, false, clientConn)
+					if err != nil {
+						return err
+					}
+					// put conn in cache ??
+				}
+				// fmt.Printf("Kinesis PutRow %v %v %v\n", rec.TableName, rec.Data, shardId)
+				err = conn.PutRow(rec.TableName, rec.Data, 0, false, false)
+
+				if err != nil {
+					u.Errorf("ERROR in PutRow, shard %s - %v", shardId, err)
+					m.errorCount.Add(1)
+					return err
+				}
+				m.processedRecs.Add(1)
+				if time.Now().After(nextCommit) {
+					conn.Flush()
+					nextCommit = time.Now().Add(time.Millisecond * time.Duration(m.CommitIntervalMs))
+				}
+			}
+			u.Errorf("shard channel closed. %v", shardId)
+			// sharedChannels was closed, clean up.
+			m.shardSessionLock.Lock()
+			defer m.shardSessionLock.Unlock()
+			for k, v := range m.shardSessionCache {
+				v.CloseSession()
+				delete(m.shardSessionCache, k)
+			}
+			return nil
+		})
+	}
+	m.HashTable = rendezvous.New(shardIds)
+	u.Infof("Created consumer. ")
+
+	return shardCount, nil
+}
+
+// MainProcessingLoop function is the main processing loop for the Kinesis consumer.
+func (m *Main) MainProcessingLoop() error {
+
+	// // Main processing loop will continue forever until a SIGKILL is received.
+	var ctx context.Context
+	for {
+		ctx, m.CancelFunc = context.WithCancel(context.Background())
+		scanErr := m.Consumer.Scan(ctx, m.scanAndProcess)
+		u.Debugf("kinesis scan returned: %v", scanErr)
+		m.Destroy()
+		if err := m.eg.Wait(); err != nil {
+			u.Errorf("session error: %v", err)
+		}
+		if scanErr != nil {
+			u.Errorf("scan error: %v", scanErr)
+		} else {
+			u.Warnf("Received Cancellation.")
+		}
+		if m.InitialPos == "TRIM_HORIZON" {
+			u.Error("can't re-initialize 'in-place' if set to TRIM_HORIZON, exiting")
+			// os.Exit(1)
+			return fmt.Errorf("can't re-initialize 'in-place' if set to TRIM_HORIZON")
+		}
+		u.Warnf("Re-initializing.")
+		var err error
+		if m.ShardCount, err = m.Init(""); err != nil {
+			u.Errorf("initialization error: %v", err)
+			u.Errorf("Exiting process.")
+			// os.Exit(1)
+			return fmt.Errorf("initialization error: %v", err)
+		}
+	}
+	// return nil
+}
+
+func (m *Main) Destroy() {
+
+	m.CancelFunc = nil
+	for _, v := range m.shardChannels {
+		close(v)
+	}
+	time.Sleep(time.Second * 5) // Allow time for completion
+}
+
+func (m *Main) scanAndProcess(v *consumer.Record) error {
+
+	out := make(map[string]interface{})
+	var table *core.Table
+
+	u.Debugf("Kinesis scanAndProcess top %v\n", v)
+
+	for _, x := range m.tableCache.TableCache {
+		if x.SelectorNode == nil {
+			continue
+		}
+		if m.IsAvro {
+			errx := avro.Unmarshal(x.AvroSchema, v.Data, &out)
+			if errx != nil {
+				// Could fail for a number of reasons but most often the 'shape' of the data is different
+				// Ideally we would grok the schema from the partition key somehow
+				continue
+			}
+
+		} else { // Default is JSON
+			err := json.Unmarshal(v.Data, &out)
+			if err != nil {
+				m.errorCount.Add(1)
+				u.Errorf("Unmarshal ERROR %v", err)
+				return nil
+			}
+		}
+		if m.preselect(x.SelectorNode, x.SelectorIdentities, out) {
+			table = x
+			break
+		}
+	}
+	if table == nil { // no match, continue
+		return nil
+	}
+
+	// Got record at this point
+	// push into the appropriate shard channel
+	if key, err := shared.GetPath(m.ShardKey, out, false, false); err != nil {
+		return err
+	} else {
+		shard := m.HashTable.GetN(1, key.(string))
+		ch, ok := m.shardChannels[shard[0]]
+		if !ok {
+			return fmt.Errorf("cannot locate channel for shard key %v", key)
+		}
+		rec := DataRecord{TableName: table.Name, Data: out}
+		fmt.Println("Pushing record to channel", rec, shard[0])
+		ch <- rec
+		m.TotalRecs.Add(1)
+		m.TotalBytes.Add(len(v.Data))
+		totalBytes.Add(float64(len(v.Data))) // tell prometheus
+	}
+	return nil // continue scanning
+}
+
+// filter row per expression
+func (m *Main) preselect(selector expr.Node, identities []string, row map[string]interface{}) bool {
+
+	ctx := m.buildEvalContext(identities, row)
+	if ctx == nil {
+		return false
+	}
+	val, ok := vm.Eval(ctx, selector)
+	if !ok {
+		u.Errorf("Preselect expression %s failed to evaluate ", selector.String())
+		os.Exit(1)
+	}
+	if val.Type() != value.BoolType {
+		u.Errorf("select expression %s does not evaluate to a boolean value", selector.String())
+		os.Exit(1)
+	}
+	return val.Value().(bool)
+}
+
+func (m *Main) buildEvalContext(identities []string, row map[string]interface{}) *datasource.ContextSimple {
+
+	data := make(map[string]interface{})
+	for _, v := range identities {
+		var path string
+		if v[0] == '/' {
+			path = v[1:]
+		} else {
+			path = v
+		}
+		if l, err := shared.GetPath(path, row, false, false); err == nil {
+			data[v] = l
+		} else {
+			return nil
+		}
+	}
+	return datasource.NewContextSimpleNative(data)
+}
+
+func (m *Main) schemaChangeListener(e shared.SchemaChangeEvent) {
+
+	if m.CancelFunc != nil {
+		m.CancelFunc()
+	}
+	switch e.Event {
+	case shared.Drop:
+		//m.sessionPool.Recover(nil)
+		u.Warnf("Dropped table %s", e.Table)
+		delete(m.tableCache.TableCache, e.Table)
+	case shared.Modify:
+		u.Warnf("Truncated table %s", e.Table)
+	case shared.Create:
+		//m.sessionPool.Recover(nil)
+		delete(m.tableCache.TableCache, e.Table)
+		u.Warnf("Created table %s", e.Table)
+	}
+	m.shardSessionLock.Lock()
+	defer m.shardSessionLock.Unlock()
+	for k, v := range m.shardSessionCache {
+		v.CloseSession()
+		delete(m.shardSessionCache, k)
+	}
+}
+
+// printStats outputs to Log current status of Kinesis consumer
+// Includes data on processed: bytes, records, time duration in seconds, and rate of bytes per sec"
+func (m *Main) PrintStats() *time.Ticker {
+	t := time.NewTicker(time.Second * 10)
+	start := time.Now()
+	lastTime := time.Now()
+	go func() {
+		for range t.C {
+			duration := time.Since(start)
+			bytes := m.TotalBytes.Get()
+			u.Infof("Bytes: %s, Records: %v, Processed: %v, Errors: %v, Duration: %v, Rate: %v/s",
+				core.Bytes(bytes), m.TotalRecs.Get(), m.processedRecs.Get(), m.errorCount.Get(), duration,
+				core.Bytes(float64(bytes)/duration.Seconds()))
+			lastTime = m.publishMetrics(duration, lastTime)
+		}
+	}()
+	return t
+}
+
+func (m *Main) publishMetrics(upTime time.Duration, lastPublishedAt time.Time) time.Time {
+
+	interval := time.Since(lastPublishedAt).Seconds()
+	_, err := m.metrics.PutMetricData(&cloudwatch.PutMetricDataInput{
+		Namespace: aws.String("Quanta-Consumer/Records"),
+		MetricData: []*cloudwatch.MetricDatum{
+			{
+				MetricName: aws.String("Arrived"),
+				Unit:       aws.String("Count"),
+				Value:      aws.Float64(float64(m.TotalRecs.Get())),
+				Dimensions: []*cloudwatch.Dimension{
+					{
+						Name:  aws.String("Stream"),
+						Value: aws.String(m.Stream),
+					},
+				},
+			},
+			{
+				MetricName: aws.String("RecordsPerSec"),
+				Unit:       aws.String("Count/Second"),
+				Value:      aws.Float64(float64(m.TotalRecs.Get()-m.totalRecsL.Get()) / interval),
+				Dimensions: []*cloudwatch.Dimension{
+					{
+						Name:  aws.String("Stream"),
+						Value: aws.String(m.Stream),
+					},
+				},
+			},
+			{
+				MetricName: aws.String("Processed"),
+				Unit:       aws.String("Count"),
+				Value:      aws.Float64(float64(m.processedRecs.Get())),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+			{
+				MetricName: aws.String("ProcessedPerSecond"),
+				Unit:       aws.String("Count/Second"),
+				Value:      aws.Float64(float64(m.processedRecs.Get()-m.processedRecL.Get()) / interval),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+			{
+				MetricName: aws.String("Errors"),
+				Unit:       aws.String("Count"),
+				Value:      aws.Float64(float64(m.errorCount.Get())),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+			{
+				MetricName: aws.String("ProcessedBytes"),
+				Unit:       aws.String("Bytes"),
+				Value:      aws.Float64(float64(m.TotalBytes.Get())),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+			{
+				MetricName: aws.String("BytesPerSec"),
+				Unit:       aws.String("Bytes/Second"),
+				Value:      aws.Float64(float64(m.TotalBytes.Get()-m.totalBytesL.Get()) / interval),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+			{
+				MetricName: aws.String("UpTimeHours"),
+				Unit:       aws.String("Count"),
+				Value:      aws.Float64(float64(upTime) / float64(1000000000*3600)),
+				/*
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("Table"),
+							Value: aws.String(m.Index),
+						},
+					},
+				*/
+			},
+		},
+	})
+	// Set Prometheus values
+	totalRecs.Set(float64(m.TotalRecs.Get()))
+	totalRecsPerSec.Set(float64(m.TotalRecs.Get()-m.totalRecsL.Get()) / interval)
+	processedRecs.Set(float64(m.processedRecs.Get()))
+	processedRecsPerSec.Set(float64(m.processedRecs.Get()-m.processedRecL.Get()) / interval)
+	errors.Set(float64(m.errorCount.Get()))
+	processedBytes.Set(float64(m.TotalBytes.Get()))
+	processedBytesPerSec.Set(float64(m.TotalBytes.Get()-m.totalBytesL.Get()) / interval)
+	uptimeHours.Set(float64(upTime) / float64(1000000000*3600))
+
+	m.totalRecsL.Set(m.TotalRecs.Get())
+	m.processedRecL.Set(m.processedRecs.Get())
+	m.totalBytesL.Set(m.TotalBytes.Get())
+	if err != nil {
+		u.Error(err)
+	}
+	return time.Now()
+}
+
+// Global storage for Prometheus metrics
+var (
+	totalRecs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consumer_records_arrived",
+		Help: "The total number of records consumed",
+	})
+
+	totalRecsPerSec = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consumer_records_arrived_per_sec",
+		Help: "The total number of records consumed per second",
+	})
+
+	processedRecs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consumer_records_processed",
+		Help: "The number of records processed",
+	})
+
+	processedRecsPerSec = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consumer_records_processed_per_sec",
+		Help: "The number of records processed per second",
+	})
+
+	totalBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consumer_bytes_arrived",
+		Help: "The total number of bytes consumed",
+	})
+
+	errors = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "total_errors",
+		Help: "The total number of errors",
+	})
+
+	processedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "processed_bytes",
+		Help: "The total number of processed bytes",
+	})
+
+	processedBytesPerSec = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "processed_bytes_per_second",
+		Help: "The total number of processed bytes per second",
+	})
+
+	uptimeHours = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "uptime_hours_kinesis",
+		Help: "Hours of up time",
+	})
+)
+
+// Counter - Generic counter with mutex (threading) support
+type Counter struct {
+	num  int64
+	lock sync.Mutex
+}
+
+// Add function provides thread safe addition of counter value based on input parameter.
+func (c *Counter) Add(n int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.num += int64(n)
+}
+
+// Get function provides thread safe read of counter value.
+func (c *Counter) Get() (ret int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	ret = c.num
+	return
+}
+
+// Set function provides thread safe set of counter value.
+func (c *Counter) Set(n int64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.num = n
+}
+
+// QuantaRetryer used for storage
+type QuantaRetryer struct {
+	store.Retryer
+}
+
+// ShouldRetry implements custom logic for when errors should retry
+func (r *QuantaRetryer) ShouldRetry(err error) bool {
+	switch err.(type) {
+	case *types.ProvisionedThroughputExceededException, *types.LimitExceededException:
+		return true
+	}
+	return false
+}

--- a/quanta-kinesis-consumer-lib/q-kinesis-lib.go
+++ b/quanta-kinesis-consumer-lib/q-kinesis-lib.go
@@ -319,7 +319,7 @@ func (m *Main) scanAndProcess(v *consumer.Record) error {
 	out := make(map[string]interface{})
 	var table *core.Table
 
-	u.Debugf("Kinesis scanAndProcess top %v\n", v)
+	// u.Debugf("Kinesis scanAndProcess top %v\n", v)
 
 	for _, x := range m.tableCache.TableCache {
 		if x.SelectorNode == nil {
@@ -361,7 +361,7 @@ func (m *Main) scanAndProcess(v *consumer.Record) error {
 			return fmt.Errorf("cannot locate channel for shard key %v", key)
 		}
 		rec := DataRecord{TableName: table.Name, Data: out}
-		fmt.Println("Pushing record to channel", rec, shard[0])
+		// fmt.Println("Pushing record to channel", rec, shard[0])
 		ch <- rec
 		m.TotalRecs.Add(1)
 		m.TotalBytes.Add(len(v.Data))

--- a/quanta-kinesis-consumer-lib/stream_test.go
+++ b/quanta-kinesis-consumer-lib/stream_test.go
@@ -1,0 +1,269 @@
+package q_kinesis_lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/disney/quanta/qlbridge/expr"
+	"github.com/disney/quanta/test"
+	"github.com/stretchr/testify/suite"
+)
+
+// Consul in a terminal window must be ON.
+// Localstack must be running. See the README.md in this directory.
+
+const stream = "test-stream"
+const region = "us-east-1"
+const shardCount = 4
+
+// THIS is the entry point for the suite
+func TestEntrypoint(t *testing.T) {
+	ourSuite := new(Kinesis_test_struct)
+	suite.Run(t, ourSuite)
+}
+
+// TestOne Send some rows to a kinesis stream. NOT the entry point.
+func (suite *Kinesis_test_struct) TestOne() {
+
+	test.AnalyzeRow(*suite.state.ProxyConnect, []string{"quanta-admin drop customers_qa"}, true)
+	test.AnalyzeRow(*suite.state.ProxyConnect, []string{"quanta-admin create customers_qa"}, true)
+
+	is_localstack := os.Getenv("LOCALSTACK_ENV") == "true"
+	fmt.Println("is_localstack", is_localstack)
+
+	partionKey := "what_is_this" // an AWS feature?
+
+	sess, errx := session.NewSession(&aws.Config{
+		Region:   aws.String(region),
+		Endpoint: aws.String("http://localhost:4566"),
+	})
+	check(errx)
+	kc := kinesis.New(sess)
+
+	streamName := aws.String(stream)
+
+	streamAlreadyExists := true
+	_, err := kc.DescribeStream(&kinesis.DescribeStreamInput{StreamName: streamName})
+	tmpstr := fmt.Sprintf("%s", err)
+	if strings.HasPrefix(tmpstr, "ResourceNotFoundException:") {
+		streamAlreadyExists = false
+	}
+	if !streamAlreadyExists {
+		out, err := kc.CreateStream(&kinesis.CreateStreamInput{
+			ShardCount: aws.Int64(shardCount),
+			StreamName: streamName,
+		})
+		check(err)
+		fmt.Printf("CreateStream %v\n", out)
+		err = kc.WaitUntilStreamExists(&kinesis.DescribeStreamInput{StreamName: streamName})
+		check(err)
+		fmt.Printf("WaitUntilStreamExists %v\n", err)
+
+	}
+	fmt.Println("streamAlreadyExists", streamAlreadyExists)
+
+	defer func() {
+		_, err := kc.DeleteStream(&kinesis.DeleteStreamInput{StreamName: streamName})
+		check(err)
+		err = kc.WaitUntilStreamNotExists(&kinesis.DescribeStreamInput{StreamName: streamName})
+		check(err)
+	}()
+
+	streams, err := kc.DescribeStream(&kinesis.DescribeStreamInput{StreamName: streamName})
+	check(err)
+	_ = streams
+	// fmt.Printf("DescribeStream %v\n", streams)
+
+	// start the consumer
+	main := NewMain() // Main{}
+	main.Stream = stream
+	main.Region = region
+	main.Schema = "quanta"
+	main.ScanInterval = 1000 // ms
+	main.Port = int(4000)
+	main.ConsulAddr = "127.0.0.1:8500"
+	main.InitialPos = "TRIM_HORIZON" // "LATEST"
+
+	// eg. /data/activitySessionId in prod
+	// this is some required field in a record that is unique and can be used to shard the data.
+	main.ShardKey = "cust_id"
+
+	// push some records to k while the consumer starts
+	preloadDone := false
+	go func() {
+		for i := 0; i < 100; i++ {
+			sqlstr := fmt.Sprintf(`{"first_name": "%s", "last_name": "Doe700","cust_id":"%v"}`, test.GetPseudoRandomWord(i+1880), i+700)
+			putOutput, err := kc.PutRecord(&kinesis.PutRecordInput{
+				Data:         []byte(sqlstr),
+				StreamName:   streamName,
+				PartitionKey: aws.String(partionKey),
+			})
+			check(err)
+			_ = putOutput
+			// fmt.Printf("PutRecord 700 %v\n", putOutput)
+			time.Sleep(100 * time.Millisecond)
+		}
+		preloadDone = true
+	}()
+
+	time.Sleep(2000 * time.Millisecond)
+
+	main.ShardCount, err = main.Init("http://localhost:4566")
+	check(err)
+
+	fmt.Println("main ShardCount", main.ShardCount)
+	fmt.Println("main tables", main.tableCache.TableCache)
+
+	table := main.tableCache.TableCache["customers_qa"]
+	table.SelectorNode, _ = expr.ParseExpression("true") // TODO: what is this? How is it used?
+	// preload 3 records using PutRecords API
+	entries := make([]*kinesis.PutRecordsRequestEntry, 3)
+	for i := 0; i < len(entries); i++ {
+		sqlstr := fmt.Sprintf(`{"first_name": "%s", "last_name": "Doe200","cust_id":"%v"}`, test.GetPseudoRandomWord(i+1900), i+200)
+		entries[i] = &kinesis.PutRecordsRequestEntry{
+			Data:         []byte(sqlstr),
+			PartitionKey: aws.String(partionKey),
+		}
+	}
+	// fmt.Printf("entries to put: %v\n", entries)
+	putsOutput, err := kc.PutRecords(&kinesis.PutRecordsInput{
+		Records:    entries,
+		StreamName: streamName,
+	})
+	check(err)
+	// putsOutput has Records, and its shard id and sequence enumber.
+	fmt.Printf("preload PutRecords by test %v\n", len(putsOutput.Records))
+
+	go func() {
+		fmt.Println("main.MainProcessingLoop START")
+		main.MainProcessingLoop()
+		fmt.Println("main.MainProcessingLoop EXIT")
+	}()
+
+	// start adding records
+	fmt.Println("adding mo records")
+	// time.Sleep(1 * time.Second) // let main get ready
+
+	if preloadDone { // we want for the background record puts to still be going.
+		suite.False(preloadDone)
+	}
+
+	jsonrec := fmt.Sprintf(`{"first_name": "%s", "last_name": "Doe1","cust_id":"%v"}`, test.GetPseudoRandomWord(1), 1)
+	putOutput, err := kc.PutRecord(&kinesis.PutRecordInput{
+		Data:         []byte(jsonrec),
+		StreamName:   streamName,
+		PartitionKey: aws.String(partionKey),
+	})
+	check(err)
+	fmt.Printf("PutRecord 1 %v\n", putOutput)
+
+	jsonrec = fmt.Sprintf(`{"first_name": "%s", "last_name": "Doe2","cust_id":"%v"}`, test.GetPseudoRandomWord(2), 2)
+	putOutput, err = kc.PutRecord(&kinesis.PutRecordInput{
+		Data:         []byte(jsonrec),
+		StreamName:   streamName,
+		PartitionKey: aws.String(partionKey),
+	})
+	check(err)
+	fmt.Printf("PutRecord 2 %v\n", putOutput)
+
+	// put 10 records using PutRecords API
+	entries = make([]*kinesis.PutRecordsRequestEntry, 10)
+	for i := 0; i < len(entries); i++ {
+		sqlstr := fmt.Sprintf(`{"first_name": "%s", "last_name": "Doe100","cust_id":"%v"}`, test.GetPseudoRandomWord(i+100), i+100)
+		entries[i] = &kinesis.PutRecordsRequestEntry{
+			Data:         []byte(sqlstr),
+			PartitionKey: aws.String(partionKey),
+		}
+	}
+	// fmt.Printf("entries to put: %v\n", entries)
+	putsOutput, err = kc.PutRecords(&kinesis.PutRecordsInput{
+		Records:    entries,
+		StreamName: streamName,
+	})
+	check(err)
+
+	for !preloadDone {
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// kinesis.IncomingRecords ?? how do we check that all the k records were consumed??
+	time.Sleep(5 * time.Second) // let threads consume channels
+	test.AnalyzeRow(*suite.state.ProxyConnect, []string{"commit"}, true)
+	// putsOutput has Records, and its shard id and sequence enumber.
+	fmt.Printf("records put by test %v\n", len(putsOutput.Records))
+	time.Sleep(5 * time.Second) // let threads consume channels
+
+	// check that the records happened.
+
+	got := test.AnalyzeRow(*suite.state.ProxyConnect, []string{"select cust_id,first_name,last_name from customers_qa;@17"}, true)
+	check(got.Err)
+	for i := 0; i < len(got.RowDataArray); i++ {
+		json, err := json.Marshal(got.RowDataArray[i])
+		check(err)
+		fmt.Printf("select found %v\n", string(json))
+	}
+	fmt.Printf("select found count %v\n", len(got.RowDataArray))
+	fmt.Printf("select found count %v\n", got.ActualRowCount)
+	suite.EqualValues(115, got.ActualRowCount)
+
+	// time.Sleep(1 * time.Second) // jus a sec
+	if main.CancelFunc != nil {
+		main.CancelFunc() // stop the consumer
+	}
+
+	suite.EqualValues(suite.Total.ExpectedRowcount, suite.Total.ActualRowCount)
+	suite.EqualValues(0, len(suite.Total.FailedChildren))
+}
+
+type Kinesis_test_struct struct {
+	// test.BaseDockerSuite
+
+	suite.Suite
+	Total test.SqlInfo
+	state *test.ClusterLocalState
+}
+
+func (suite *Kinesis_test_struct) SetupSuite() {
+
+	// TODO: don't stop the localstack docker container.
+
+	// stop and remove all containers
+	// test.Shell("docker stop $(docker ps -aq)", "")
+	// test.Shell("docker rm $(docker ps -aq)", "")
+
+	// suite.SetupDockerCluster(3, 1)
+
+	// the local cluster method
+	if !test.IsLocalRunning() { // if no cluster is up
+		err := os.RemoveAll("../test/localClusterData/") // start fresh
+		check(err)
+	}
+	// ensure we have a cluster on localhost, start one if necessary
+	suite.state = test.Ensure_cluster(3)
+
+}
+
+func (suite *Kinesis_test_struct) TearDownSuite() {
+	// leave the cluster running
+	// or:
+	// stop and remove all containers
+	// test.Shell("docker stop $(docker ps -aq)", "")
+	// test.Shell("docker rm $(docker ps -aq)", "")
+
+	// just let it crash suite.state.Release()
+
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Println("ERROR ERROR check err", err)
+		// panic(err.Error())
+	}
+}

--- a/quanta-kinesis-consumer/quanta-kinesis-consumer.go
+++ b/quanta-kinesis-consumer/quanta-kinesis-consumer.go
@@ -1,117 +1,32 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
 	u "github.com/araddon/gou"
-	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/disney/quanta/core"
 	"github.com/disney/quanta/custom/functions"
-	"github.com/disney/quanta/qlbridge/datasource"
-	"github.com/disney/quanta/qlbridge/expr"
 	"github.com/disney/quanta/qlbridge/expr/builtins"
-	"github.com/disney/quanta/qlbridge/value"
-	"github.com/disney/quanta/qlbridge/vm"
+	q_kinesis_lib "github.com/disney/quanta/quanta-kinesis-consumer-lib"
 	"github.com/disney/quanta/shared"
-	"github.com/hamba/avro/v2"
-	consumer "github.com/harlow/kinesis-consumer"
-	store "github.com/harlow/kinesis-consumer/store/ddb"
-	"github.com/hashicorp/consul/api"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/stvp/rendezvous"
-	"golang.org/x/sync/errgroup"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Variables to identify the build
 var (
-	Version          string
-	Build            string
-	ShardChannelSize = 10000
-	EPOCH, _         = time.ParseInLocation(time.RFC3339, "2000-01-01T00:00:00+00:00", time.UTC)
+	Version string
+	Build   string
+	// ShardChannelSize = 10000
+	EPOCH, _ = time.ParseInLocation(time.RFC3339, "2000-01-01T00:00:00+00:00", time.UTC)
 )
-
-// Exit Codes
-const (
-	Success = 0
-	appName = "Kinesis-Consumer"
-)
-
-// Main struct defines command line arguments variables and various global meta-data associated with record loads.
-type Main struct {
-	Stream              string
-	Region              string
-	Schema              string
-	totalBytes          *Counter
-	totalBytesL         *Counter
-	totalRecs           *Counter
-	totalRecsL          *Counter
-	errorCount          *Counter
-	poolPercent         *Counter
-	Port                int
-	ConsulAddr          string
-	ShardCount          int
-	lock                *api.Lock
-	consumer            *consumer.Consumer
-	InitialPos          string
-	IsAvro              bool
-	CheckpointDB        bool
-	CheckpointTable     string
-	AssumeRoleArn       string
-	AssumeRoleArnRegion string
-	Deaggregate         bool
-	Collate             bool
-	ShardKey            string
-	HashTable           *rendezvous.Table
-	shardChannels       map[string]chan DataRecord
-	shardSessions       map[string]*core.Session
-	eg                  errgroup.Group
-	cancelFunc          context.CancelFunc
-	CommitIntervalMs    int
-	processedRecs       *Counter
-	processedRecL       *Counter
-	scanInterval        int
-	metrics             *cloudwatch.CloudWatch
-	tableCache          *core.TableCacheStruct
-}
-
-// NewMain allocates a new pointer to Main struct with empty record counter
-func NewMain() *Main {
-	m := &Main{
-		totalRecs:     &Counter{},
-		totalRecsL:    &Counter{},
-		totalBytes:    &Counter{},
-		totalBytesL:   &Counter{},
-		processedRecs: &Counter{},
-		processedRecL: &Counter{},
-		errorCount:    &Counter{},
-	}
-	m.tableCache = core.NewTableCacheStruct()
-	return m
-}
-
-type DataRecord struct {
-	TableName string
-	Data      map[string]interface{}
-}
 
 func main() {
 
@@ -138,16 +53,16 @@ func main() {
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	shared.InitLogging(*logLevel, *environment, appName, Version, "Quanta")
+	shared.InitLogging(*logLevel, *environment, q_kinesis_lib.AppName, Version, "Quanta")
 
 	builtins.LoadAllBuiltins()
 	functions.LoadAll()
 
-	main := NewMain()
+	main := q_kinesis_lib.NewMain()
 	main.Stream = *stream
 	main.Region = *region
 	main.Schema = *schema
-	main.scanInterval = *scanInterval
+	main.ScanInterval = *scanInterval
 	main.Port = int(*port)
 	main.ConsulAddr = *consul
 
@@ -155,7 +70,7 @@ func main() {
 	log.Printf("Kinesis stream %v.", main.Stream)
 	log.Printf("Kinesis region %v.", main.Region)
 	log.Printf("Schema name %v.", main.Schema)
-	log.Printf("Scan interval (milliseconds) %d.", main.scanInterval)
+	log.Printf("Scan interval (milliseconds) %d.", main.ScanInterval)
 	if *commitInterval == 0 {
 		log.Printf("Commits will occur after each row.")
 	} else {
@@ -189,7 +104,7 @@ func main() {
 			main.InitialPos = "AFTER_SEQUENCE_NUMBER"
 		}
 	}
-	
+
 	if shardKey != nil {
 		v := *shardKey
 		var path string
@@ -228,7 +143,7 @@ func main() {
 
 	var err error
 
-	if main.ShardCount, err = main.Init(); err != nil {
+	if main.ShardCount, err = main.Init(""); err != nil {
 		u.Error(err)
 		os.Exit(1)
 	}
@@ -239,597 +154,29 @@ func main() {
 		http.ListenAndServe(":2112", nil)
 	}()
 
-	var ticker *time.Ticker
-	ticker = main.printStats()
+	// var ticker *time.Ticker TODO: implement or delete
+	// ticker = main.PrintStats()
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		for range c {
-			u.Warnf("Interrupted,  Bytes processed: %s, Records: %v", core.Bytes(main.totalBytes.Get()),
-				main.totalRecs.Get())
+			u.Warnf("Interrupted,  Bytes processed: %s, Records: %v", core.Bytes(main.TotalBytes.Get()),
+				main.TotalRecs.Get())
 			u.Errorf("Interrupt received, calling cancel function")
-			if main.cancelFunc != nil {
-				main.cancelFunc()
+			if main.CancelFunc != nil {
+				main.CancelFunc()
 			}
 		}
 	}()
 
-	// Main processing loop will continue forever until a SIGKILL is received.
-	var ctx context.Context
-	for {
-		ctx, main.cancelFunc = context.WithCancel(context.Background())
-		scanErr := main.consumer.Scan(ctx, main.scanAndProcess)
-		main.destroy()
-		if err := main.eg.Wait(); err != nil {
-			u.Errorf("session error: %v", err)
-		}
-		if scanErr != nil {
-			u.Errorf("scan error: %v", scanErr)
-		} else {
-			u.Warnf("Received Cancellation.")
-		}
-		if main.InitialPos == "TRIM_HORIZON" {
-			u.Error("can't re-initialize 'in-place' if set to TRIM_HORIZON, exiting")
-			os.Exit(1)
-		}
-		u.Warnf("Re-initializing.")
-		if main.ShardCount, err = main.Init(); err != nil {
-			u.Errorf("initialization error: %v", err)
-			u.Errorf("Exiting process.")
-			os.Exit(1)
-		}
+	err = main.MainProcessingLoop() // normally never returns.
+	if err != nil {
+		exitErrorf("MainProcessingLoop error exit: %v", err)
 	}
-	ticker.Stop()
-}
-
-func (m *Main) destroy() {
-
-	m.cancelFunc = nil
-	for _, v := range m.shardChannels {
-		close(v)
-	}
-	time.Sleep(time.Second * 5) // Allow time for completion
-}
-
-func (m *Main) scanAndProcess(v *consumer.Record) error {
-
-	out := make(map[string]interface{})
-	var table *core.Table
-
-	for _, x := range m.tableCache.TableCache {
-		if x.SelectorNode == nil {
-			continue
-		}
-		if m.IsAvro {
-			errx := avro.Unmarshal(x.AvroSchema, v.Data, &out)
-			if errx != nil {
-				// Could fail for a number of reasons but most often the 'shape' of the data is different
-				// Ideally we would grok the schema from the partition key somehow
-				continue
-			}
-
-		} else { // Default is JSON
-			err := json.Unmarshal(v.Data, &out)
-			if err != nil {
-				m.errorCount.Add(1)
-				u.Errorf("Unmarshal ERROR %v", err)
-				return nil
-			}
-		}
-		if m.preselect(x.SelectorNode, x.SelectorIdentities, out) {
-			table = x
-			break
-		}
-	}
-	if table == nil { // no match, continue
-		return nil
-	}
-
-	// Got record at this point
-	// push into the appropriate shard channel
-	if key, err := shared.GetPath(m.ShardKey, out, false, false); err != nil {
-		return err
-	} else {
-		shard := m.HashTable.GetN(1, key.(string))
-		ch, ok := m.shardChannels[shard[0]]
-		if !ok {
-			return fmt.Errorf("Cannot locate channel for shard key %v", key)
-		}
-		rec := DataRecord{TableName: table.Name, Data: out}
-		ch <- rec
-		m.totalRecs.Add(1)
-		m.totalBytes.Add(len(v.Data))
-	}
-	return nil // continue scanning
-}
-
-// filter row per expression
-func (m *Main) preselect(selector expr.Node, identities []string, row map[string]interface{}) bool {
-
-	ctx := m.buildEvalContext(identities, row)
-	if ctx == nil {
-		return false
-	}
-	val, ok := vm.Eval(ctx, selector)
-	if !ok {
-		u.Errorf("Preselect expression %s failed to evaluate ", selector.String())
-		os.Exit(1)
-	}
-	if val.Type() != value.BoolType {
-		u.Errorf("select expression %s does not evaluate to a boolean value", selector.String())
-		os.Exit(1)
-	}
-	return val.Value().(bool)
-}
-
-func (m *Main) buildEvalContext(identities []string, row map[string]interface{}) *datasource.ContextSimple {
-
-	data := make(map[string]interface{})
-	for _, v := range identities {
-		var path string
-		if v[0] == '/' {
-			path = v[1:]
-		} else {
-			path = v
-		}
-		if l, err := shared.GetPath(path, row, false, false); err == nil {
-			data[v] = l
-		} else {
-			return nil
-		}
-	}
-	return datasource.NewContextSimpleNative(data)
 }
 
 func exitErrorf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	os.Exit(1)
-}
-
-/*
-// MemberLeft - Implements member leave notification due to failure.
-func (m *Main) MemberLeft(nodeID string, index int) {
-
-	u.Warnf("node %v left the cluster, purging sessions", nodeID)
-	go m.recoverInflight(m.sessionPool.Recover)
-}
-
-// MemberJoined - A new node joined the cluster.
-func (m *Main) MemberJoined(nodeID, ipAddress string, index int) {
-
-	u.Warnf("node %v joined the cluster, purging sessions", nodeID)
-	go m.recoverInflight(m.sessionPool.Recover)
-}
-
-// recover in-flight data in new thread
-func (m *Main) recoverInflight(recoverFunc func(unflushedCh chan *shared.BatchBuffer)) {
-
-	sess, err := m.sessionPool.NewSession(m.Index)
-	if err != nil {
-		u.Errorf("recoverInflight error creating recovery session %v", err)
-	}
-	rc := make(chan *shared.BatchBuffer, runtime.NumCPU())
-	recoverFunc(rc)
-	close(rc)
-	i := 1
-	for batch := range rc {
-		u.Infof("recoverInflight session %d", i)
-		batch.MergeInto(sess.BatchBuffer)
-		i++
-	}
-	err = sess.CloseSession() // Will flush first
-	if err != nil {
-		u.Errorf("recoverInflight error closing session %v", err)
-	}
-}
-*/
-
-func (m *Main) schemaChangeListener(e shared.SchemaChangeEvent) {
-
-	if m.cancelFunc != nil {
-		m.cancelFunc()
-	}
-	switch e.Event {
-	case shared.Drop:
-		//m.sessionPool.Recover(nil)
-		u.Warnf("Dropped table %s", e.Table)
-		delete(m.tableCache.TableCache, e.Table)
-	case shared.Modify:
-		u.Warnf("Truncated table %s", e.Table)
-	case shared.Create:
-		//m.sessionPool.Recover(nil)
-		delete(m.tableCache.TableCache, e.Table)
-		u.Warnf("Created table %s", e.Table)
-	}
-	for k, v := range m.shardSessions {
-		v.CloseSession()
-		delete(m.shardSessions, k)
-	}
-}
-
-// Init function initilizations loader.
-// Establishes session with bitmap server and Kinesis
-func (m *Main) Init() (int, error) {
-
-	consulConfig := &api.Config{Address: m.ConsulAddr}
-	consulClient, err := api.NewClient(consulConfig)
-	if err != nil {
-		return 0, err
-	}
-
-	// Register for Schema changes
-	err = shared.RegisterSchemaChangeListener(consulConfig, m.schemaChangeListener)
-	if err != nil {
-		return 0, err
-	}
-
-	clientConn := shared.NewDefaultConnection("ki")
-	clientConn.ServicePort = m.Port
-	clientConn.Quorum = 3
-	if err := clientConn.Connect(consulClient); err != nil {
-		u.Error(err)
-		os.Exit(1)
-	}
-
-	// Register member leave/join
-	//clientConn.RegisterService(m)
-	sess, errx := session.NewSession(&aws.Config{
-		Region: aws.String(m.Region),
-	})
-	if errx != nil {
-		return 0, errx
-	}
-
-	var kc *kinesis.Kinesis
-	if m.AssumeRoleArn != "" {
-		creds := stscreds.NewCredentials(sess, m.AssumeRoleArn)
-		config := aws.NewConfig().
-			WithCredentials(creds).
-			WithRegion(m.AssumeRoleArnRegion).
-			WithMaxRetries(10)
-		kc = kinesis.New(sess, config)
-	} else {
-		kc = kinesis.New(sess)
-	}
-
-	streamName := aws.String(m.Stream)
-	shout, err := kc.ListShards(&kinesis.ListShardsInput{StreamName: streamName})
-	if err != nil {
-		return 0, err
-	}
-	shardCount := len(shout.Shards)
-	dynamoDbClient := dynamodb.New(sess)
-
-	db, err := store.New(appName, m.CheckpointTable, store.WithDynamoClient(dynamoDbClient), store.WithRetryer(&QuantaRetryer{}))
-	if err != nil {
-		u.Errorf("checkpoint storage initialization error: %v", err)
-		os.Exit(1)
-	}
-
-	if m.CheckpointDB {
-		m.consumer, err = consumer.New(
-			m.Stream,
-			consumer.WithClient(kc),
-			consumer.WithShardIteratorType(m.InitialPos),
-			consumer.WithStore(db),
-			consumer.WithAggregation(m.Deaggregate),
-			consumer.WithScanInterval(time.Duration(m.scanInterval)*time.Millisecond),
-			//consumer.WithCounter(counter),
-		)
-	} else {
-		m.consumer, err = consumer.New(
-			m.Stream,
-			consumer.WithClient(kc),
-			consumer.WithShardIteratorType(m.InitialPos),
-			consumer.WithAggregation(m.Deaggregate),
-			consumer.WithScanInterval(time.Duration(m.scanInterval)*time.Millisecond),
-			//consumer.WithCounter(counter),
-		)
-	}
-	if err != nil {
-		return 0, err
-	}
-	m.metrics = cloudwatch.New(sess)
-
-	// Initialize shard channels
-	u.Warnf("Shard count = %d", shardCount)
-	m.shardChannels = make(map[string]chan DataRecord)
-	m.shardSessions = make(map[string]*core.Session)
-	shardIds := make([]string, shardCount)
-	// ClearTableCache
-	for k := range m.tableCache.TableCache {
-		delete(m.tableCache.TableCache, k)
-	}
-
-	// open all tables to populate the TableCache
-	tables, err := shared.GetTables(consulClient)
-	if err != nil {
-		return 0, err
-	}
-	for _, tableName := range tables {
-		conn, _ := core.OpenSession(m.tableCache, "", tableName, false, clientConn)
-		if conn != nil {
-			conn.CloseSession()
-		}
-	}
-
-	for i := 0; i < shardCount; i++ {
-		k := fmt.Sprintf("shard%v", i)
-		shardIds[i] = k
-		m.shardChannels[k] = make(chan DataRecord, ShardChannelSize)
-		shardId := k
-		m.eg.Go(func() error {
-			nextCommit := time.Now().Add(time.Millisecond * time.Duration(m.CommitIntervalMs))
-			for rec := range m.shardChannels[shardId] {
-				shardTableKey := fmt.Sprintf("%v+%v", shardId, rec.TableName)
-				conn, ok := m.shardSessions[shardTableKey]
-				if !ok {
-					conn, err = core.OpenSession(m.tableCache, "", rec.TableName, false, clientConn)
-					if err != nil {
-						return err
-					}
-				}
-
-				err = conn.PutRow(rec.TableName, rec.Data, 0, false, false)
-				if err != nil {
-					u.Errorf("ERROR in PutRow, shard %s - %v", shardId, err)
-					m.errorCount.Add(1)
-					return err
-				}
-				m.processedRecs.Add(1)
-				if time.Now().After(nextCommit) {
-					conn.Flush()
-					nextCommit = time.Now().Add(time.Millisecond * time.Duration(m.CommitIntervalMs))
-				}
-			}
-			// sharedChannels was closed, clean up.
-			for k, v := range m.shardSessions {
-				v.CloseSession()
-				delete(m.shardSessions, k)
-			}
-			return nil
-		})
-	}
-	m.HashTable = rendezvous.New(shardIds)
-	u.Infof("Created consumer. ")
-
-	return shardCount, nil
-}
-
-// printStats outputs to Log current status of Kinesis consumer
-// Includes data on processed: bytes, records, time duration in seconds, and rate of bytes per sec"
-func (m *Main) printStats() *time.Ticker {
-	t := time.NewTicker(time.Second * 10)
-	start := time.Now()
-	lastTime := time.Now()
-	go func() {
-		for range t.C {
-			duration := time.Since(start)
-			bytes := m.totalBytes.Get()
-			u.Infof("Bytes: %s, Records: %v, Processed: %v, Errors: %v, Duration: %v, Rate: %v/s",
-				core.Bytes(bytes), m.totalRecs.Get(), m.processedRecs.Get(), m.errorCount.Get(), duration,
-				core.Bytes(float64(bytes)/duration.Seconds()))
-			lastTime = m.publishMetrics(duration, lastTime)
-		}
-	}()
-	return t
-}
-
-// Global storage for Prometheus metrics
-var (
-	totalRecs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "consumer_records_arrived",
-		Help: "The total number of records consumed",
-	})
-
-	totalRecsPerSec = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "consumer_records_arrived_per_sec",
-		Help: "The total number of records consumed per second",
-	})
-
-	processedRecs = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "consumer_records_processed",
-		Help: "The number of records processed",
-	})
-
-	processedRecsPerSec = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "consumer_records_processed_per_sec",
-		Help: "The number of records processed per second",
-	})
-
-	totalBytes = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "consumer_bytes_arrived",
-		Help: "The total number of bytes consumed",
-	})
-
-	errors = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "total_errors",
-		Help: "The total number of errors",
-	})
-
-	processedBytes = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "processed_bytes",
-		Help: "The total number of processed bytes",
-	})
-
-	processedBytesPerSec = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "processed_bytes_per_second",
-		Help: "The total number of processed bytes per second",
-	})
-
-	uptimeHours = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "uptime_hours",
-		Help: "Hours of up time",
-	})
-)
-
-func (m *Main) publishMetrics(upTime time.Duration, lastPublishedAt time.Time) time.Time {
-
-	interval := time.Since(lastPublishedAt).Seconds()
-	_, err := m.metrics.PutMetricData(&cloudwatch.PutMetricDataInput{
-		Namespace: aws.String("Quanta-Consumer/Records"),
-		MetricData: []*cloudwatch.MetricDatum{
-			{
-				MetricName: aws.String("Arrived"),
-				Unit:       aws.String("Count"),
-				Value:      aws.Float64(float64(m.totalRecs.Get())),
-				Dimensions: []*cloudwatch.Dimension{
-					{
-						Name:  aws.String("Stream"),
-						Value: aws.String(m.Stream),
-					},
-				},
-			},
-			{
-				MetricName: aws.String("RecordsPerSec"),
-				Unit:       aws.String("Count/Second"),
-				Value:      aws.Float64(float64(m.totalRecs.Get()-m.totalRecsL.Get()) / interval),
-				Dimensions: []*cloudwatch.Dimension{
-					{
-						Name:  aws.String("Stream"),
-						Value: aws.String(m.Stream),
-					},
-				},
-			},
-			{
-				MetricName: aws.String("Processed"),
-				Unit:       aws.String("Count"),
-				Value:      aws.Float64(float64(m.processedRecs.Get())),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-			{
-				MetricName: aws.String("ProcessedPerSecond"),
-				Unit:       aws.String("Count/Second"),
-				Value:      aws.Float64(float64(m.processedRecs.Get()-m.processedRecL.Get()) / interval),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-			{
-				MetricName: aws.String("Errors"),
-				Unit:       aws.String("Count"),
-				Value:      aws.Float64(float64(m.errorCount.Get())),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-			{
-				MetricName: aws.String("ProcessedBytes"),
-				Unit:       aws.String("Bytes"),
-				Value:      aws.Float64(float64(m.totalBytes.Get())),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-			{
-				MetricName: aws.String("BytesPerSec"),
-				Unit:       aws.String("Bytes/Second"),
-				Value:      aws.Float64(float64(m.totalBytes.Get()-m.totalBytesL.Get()) / interval),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-			{
-				MetricName: aws.String("UpTimeHours"),
-				Unit:       aws.String("Count"),
-				Value:      aws.Float64(float64(upTime) / float64(1000000000*3600)),
-				/*
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("Table"),
-							Value: aws.String(m.Index),
-						},
-					},
-				*/
-			},
-		},
-	})
-	// Set Prometheus values
-	totalRecs.Set(float64(m.totalRecs.Get()))
-	totalRecsPerSec.Set(float64(m.totalRecs.Get()-m.totalRecsL.Get()) / interval)
-	processedRecs.Set(float64(m.processedRecs.Get()))
-	processedRecsPerSec.Set(float64(m.processedRecs.Get()-m.processedRecL.Get()) / interval)
-	errors.Set(float64(m.errorCount.Get()))
-	processedBytes.Set(float64(m.totalBytes.Get()))
-	processedBytesPerSec.Set(float64(m.totalBytes.Get()-m.totalBytesL.Get()) / interval)
-	uptimeHours.Set(float64(upTime) / float64(1000000000*3600))
-
-	m.totalRecsL.Set(m.totalRecs.Get())
-	m.processedRecL.Set(m.processedRecs.Get())
-	m.totalBytesL.Set(m.totalBytes.Get())
-	if err != nil {
-		u.Error(err)
-	}
-	return time.Now()
-}
-
-// Counter - Generic counter with mutex (threading) support
-type Counter struct {
-	num  int64
-	lock sync.Mutex
-}
-
-// Add function provides thread safe addition of counter value based on input parameter.
-func (c *Counter) Add(n int) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.num += int64(n)
-}
-
-// Get function provides thread safe read of counter value.
-func (c *Counter) Get() (ret int64) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	ret = c.num
-	return
-}
-
-// Set function provides thread safe set of counter value.
-func (c *Counter) Set(n int64) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.num = n
-	return
-}
-
-// QuantaRetryer used for storage
-type QuantaRetryer struct {
-	store.Retryer
-}
-
-// ShouldRetry implements custom logic for when errors should retry
-func (r *QuantaRetryer) ShouldRetry(err error) bool {
-	switch err.(type) {
-	case *types.ProvisionedThroughputExceededException, *types.LimitExceededException:
-		return true
-	}
-	return false
 }

--- a/test/wordlist.go
+++ b/test/wordlist.go
@@ -1,5 +1,20 @@
 package test
 
+import "strings"
+
+var Word_Array []string = nil
+
+// This is only used to generate test data.
+
+func GetPseudoRandomWord(i int) string {
+	if Word_Array == nil {
+		Word_Array = strings.Split(English_words, "\n")
+	}
+	i = i * 3121 // prime number
+	i = i % len(Word_Array)
+	return (Word_Array)[i]
+}
+
 var English_words = `as
 his
 that


### PR DESCRIPTION
The quanta-kinesis-consumer is refactored into a main and a lib.
This is to facilitate integration tests.

A test was written that exercises the quanta-kinesis-consumer. 

The fixes are the shardSessionCache and the shardSessionLock in q-kinesis-lib.go to prevent concurrent modification panics.
